### PR TITLE
Fix header inclusion

### DIFF
--- a/src/Resource.cpp
+++ b/src/Resource.cpp
@@ -1,6 +1,6 @@
 #include"Resource.h"
 
- Resource::Resource(Server server, Json::Value value):
+ Resource::Resource(Server* server, Json::Value value):
 	JSON(value),server(server){
     #ifdef DEBUG
 	std::cout <<"Constructor is working..."<<std::endl;

--- a/src/Resource.cpp
+++ b/src/Resource.cpp
@@ -1,9 +1,4 @@
-
-
 #include"Resource.h"
-#include"Server.h"
-
-
 
  Resource::Resource(Server server, Json::Value value):
 	JSON(value),server(server){

--- a/src/Resource.h
+++ b/src/Resource.h
@@ -1,8 +1,10 @@
+#ifndef __JSONAPI_CLIENT_RESOURCE_H
+#define __JSONAPI_CLIENT_RESOURCE_H
+
 #include<string>
 #include<iostream>
 #include<cstring>
 #include<map>
-#pragma once
 
 #include"ResourceIdentifier.h"
 #include"Server.h"
@@ -36,3 +38,5 @@ class Resource: public ResourceIdentifier{
 	~Resource();
 
 };
+
+#endif

--- a/src/Resource.h
+++ b/src/Resource.h
@@ -6,6 +6,8 @@
 #include<cstring>
 #include<map>
 
+class Server;
+
 #include"ResourceIdentifier.h"
 #include"Server.h"
 #include <jsoncpp/json/json.h> //adding json header for second constructor
@@ -13,10 +15,10 @@
 class Resource: public ResourceIdentifier{
     private:
 	Json::Value JSON;
-	Server server;
+	Server* server;
 
     public:
-	Resource(Server server, Json::Value value); //adding second constructor with all items from data payload
+	Resource(Server* server, Json::Value value); //adding second constructor with all items from data payload
 
 	Json::Value get_attribute(const std::string attribute_name );
 	Json::Value get_id();

--- a/src/ResourceIdentifier.cpp
+++ b/src/ResourceIdentifier.cpp
@@ -1,8 +1,5 @@
-
-
 #include"ResourceIdentifier.h"
 
-  
  ResourceIdentifier::ResourceIdentifier(const std::string id,const std::string type):
 	id_(id), type_(type){
     #ifdef DEBUG

--- a/src/ResourceIdentifier.h
+++ b/src/ResourceIdentifier.h
@@ -1,9 +1,6 @@
 #include <string>
 #include<iostream>
 #include<cstring>
-#pragma once
-
-
 
 class ResourceIdentifier{
     private:

--- a/src/ResourceIdentifier.h
+++ b/src/ResourceIdentifier.h
@@ -1,3 +1,6 @@
+#ifndef __JSONAPI_CLIENT_RESOURCEIDENTIFIER_H
+#define __JSONAPI_CLIENT_RESOURCEIDENTIFIER_H
+
 #include <string>
 #include<iostream>
 #include<cstring>
@@ -19,3 +22,4 @@ class ResourceIdentifier{
 	~ResourceIdentifier();
 };
 
+#endif

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -1,7 +1,4 @@
-
-
 #include"Server.h"
-//#include"Resource.h"
 
  Server::Server(const std::string url):
 	url_(url){

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -65,6 +65,7 @@
 	return url_;
   };
 
+ /*
  Resource Server::get_all(const std::string type){
 	std::string all_id;          //creating a new string 
 	all_id.append(get_url());    //adding url to a new string
@@ -78,6 +79,7 @@
 	return arrayOfObjects[0];
 	//return Resource( data["data"] );
   };
+  */
  
  Resource Server::get_one(const std::string type,const std::string id){
 	std::string id_one;
@@ -88,7 +90,7 @@
 	id_one.append(id);     //string with url + "/" + type + "/" + id
 	Json::Value data = get_URL(id_one); //fetching by using new url to get single object
 	Server server(id_one);
-	return Resource(server, data["data"] );
+	return Resource(&server, data["data"] );
   };
 
  Server::~Server(){

--- a/src/Server.h
+++ b/src/Server.h
@@ -6,8 +6,11 @@
 #include<cstring>
 #include<vector>
 
-#include"namespace.h"
+class Resource;
+
 #include"Resource.h"
+
+#include"namespace.h"
 
 class Server{
     private:
@@ -20,7 +23,7 @@ class Server{
 	std::string set_url(const std::string url_new); //setting url for a server
 	std::string get_url();
 
-	//Resource get_all(const std::string type); 
+	// Resource get_all(const std::string type); 
 	Resource get_one(const std::string type,const std::string id);
 
 	~Server();

--- a/src/Server.h
+++ b/src/Server.h
@@ -1,13 +1,13 @@
+#ifndef __JSONAPI_CLIENT_SERVER_H
+#define __JSONAPI_CLIENT_SERVER_H
+
 #include<string>
 #include<iostream>
 #include<cstring>
 #include<vector>
 
-#pragma once
-
 #include"namespace.h"
 #include"Resource.h"
-
 
 class Server{
     private:
@@ -25,3 +25,5 @@ class Server{
 
 	~Server();
 };
+
+#endif


### PR DESCRIPTION
I have replaced `#pragma once` with inclusion guards. The main problem preventing compilation was circular dependency between `Server` and `Resource` classes, introduced in #26. I have solved this by passing the reference of `Server` to `Resource` constructor, and adding forward definitions for classes such as:
```C++
class Server;
```
It should work now.